### PR TITLE
feat: add no SIMD version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wasm-vips",
+  "name": "@denodecom/wasm-vips",
   "version": "0.0.9",
   "description": "libvips for the browser and Node.js, compiled to WebAssembly with Emscripten",
   "homepage": "https://github.com/kleisauke/wasm-vips",
@@ -25,6 +25,17 @@
       },
       "default": "./lib/vips.js"
     },
+    "./nosimd": {
+      "browser": {
+        "import": "./lib/nosimd/vips-es6.js",
+        "require": "./lib/nosimd/vips.js"
+      },
+      "node": {
+        "import": "./lib/nosimd/vips-node.mjs",
+        "require": "./lib/nosimd/vips-node.js"
+      },
+      "default": "./lib/nosimd/vips.js"
+    },
     "./versions": "./versions.json"
   },
   "main": "lib/vips-node.js",
@@ -39,11 +50,16 @@
     "lib/vips-jxl.wasm",
     "lib/vips-resvg.wasm",
     "THIRD-PARTY-NOTICES.md",
-    "versions.json"
+    "versions.json",
+    "lib/nosimd/*"
   ],
   "scripts": {
-    "build": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh",
-    "test": "npm run test:lint && npm run test:node",
+    "build:base": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build",
+    "build:nosimd": "docker build -t wasm-vips . && docker run -it --rm -v $(pwd):/src wasm-vips ./build.sh --clean-build --variant nosimd --disable-simd",
+    "build": "npm run build:base && npm run build:nosimd",
+    "test": "npm run test:lint && npm run test:base && npm run test:nosimd",
+    "test:base": "npm run test:node",
+    "test:nosimd": "VARIANT=nosimd npm run test:node",
     "test:lint": "semistandard",
     "test:node": "npm --prefix test/unit test",
     "test:web": "serve -c test/unit/serve.json",
@@ -52,6 +68,8 @@
     "bench:web": "serve -c test/bench/serve.json"
   },
   "devDependencies": {
+    "chai": "^5.1.1",
+    "mocha": "^10.4.0",
     "semistandard": "^17.0.0",
     "serve": "^14.2.3"
   },

--- a/test/unit/node-helper.js
+++ b/test/unit/node-helper.js
@@ -1,11 +1,16 @@
 'use strict';
 
-import Vips from '../../lib/vips-node.mjs';
-
 import { tmpdir } from 'node:os';
 import { expect } from 'chai';
 
 globalThis.expect = expect;
+
+const variant = process.argv
+  .find(arg => arg.startsWith('--variant='))
+  ?.split('=')?.[1];
+const pkg = variant ? `../../lib/${variant}/vips-node.mjs` : '../../lib/vips-node.mjs';
+
+const { default: Vips } = await import(pkg);
 
 export async function mochaGlobalSetup () {
   const options = {

--- a/test/unit/package.json
+++ b/test/unit/package.json
@@ -16,7 +16,7 @@
   "author": "Kleis Auke Wolthuizen",
   "type": "module",
   "scripts": {
-    "test": "mocha -s 5000 -t 120000 *.js -r node-helper.js"
+    "test": "mocha -s 5000 -t 120000 *.js -r node-helper.js --variant=$VARIANT"
   },
   "devDependencies": {
     "chai": "^5.1.1",


### PR DESCRIPTION
This PR adds pre-built binaries without SIMD support to ensure compatibility with iOS versions earlier than 16.4.

After publishing, you can access both versions:
- **Regular version:** `@denodecom/wasm-vips`
- **Non-SIMD version:** `@denodecom/wasm-vips/nosimd`


```js
import { simd } from 'wasm-feature-detect';

let vips;
export async function loadWasmVips() {
  if (vips) {
    return vips;
  }

  const { default: Vips } = (await simd())
    ? await import(`@denodecom/wasm-vips`)
    : await import(`@denodecom/wasm-vips/nosimd`);

  const options = {
    dynamicLibraries: []
  };

  vips = await Vips(options);

  return vips;
}
```